### PR TITLE
feat(url): add endpoint to delete short URLs with permission checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prisma:generate:dev": "env-cmd -f .env.local prisma generate",
     "prisma:migrate:dev": "env-cmd -f .env.local prisma migrate dev --name init",
     "start": "node dist/src/app.js",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test:coverage": "jest --coverage",
     "test:queue": "jest --runInBand",
     "test:watch": "jest --watch"

--- a/src/api/v1/features/url/url.routes.ts
+++ b/src/api/v1/features/url/url.routes.ts
@@ -22,6 +22,7 @@ const controller = new UrlControllerImpl(service);
 const router = Router();
 
 router
+  .delete("/:shortId", authenticationMiddleware, controller.deleteUrl)
   .get("", authenticationMiddleware, controller.getUrlsByUserId)
   .get("/redirect/:shortId", controller.redirect)
   .post(

--- a/src/api/v1/features/url/url.service.ts
+++ b/src/api/v1/features/url/url.service.ts
@@ -116,8 +116,6 @@ export class UrlServiceImpl implements UrlService {
     if (!url)
       throw new ApiError(`URL with shortId ${shortId} not found`).setStatus(HTTP_STATUS.NOT_FOUND);
 
-    console.log("userId", userId, url.userId);
-
     if (!url.userId)
       throw new ApiError("Cannot delete an anonymous URL").setStatus(HTTP_STATUS.BAD_REQUEST);
 


### PR DESCRIPTION
- Add controller, service, and route for deleting short URLs by shortId
- Include error handling for not found, anonymous, and forbidden deletions
- Update and add tests for deletion scenarios
- Rename service/controller methods for consistency